### PR TITLE
Fix WEBSITES_PORT typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple Python Django application running in a Docker container. The custom ima
 ## Setting up custom image for web App on Linux 
 - Create a Web App on Linux using CLI or Azure portal
 - Configure your web app to custom image 
-- Add an App Setting ```WEBSITE_PORT = 8000 ``` for your app 
+- Add an App Setting ```WEBSITES_PORT = 8000 ``` for your app 
 - Browse your site 
  
 # Contributing


### PR DESCRIPTION
The property name is `WEBSITES_PORT` as referenced by an [article](https://docs.microsoft.com/en-us/azure/app-service/containers/tutorial-custom-docker-image#configure-environment-variables) that references this repository and as confirmed by Kudu logs for my running App Service for Containers instance. The following shows the app settings that are indeed passed to containers:

`2018-04-10 04:16:49.312 INFO  - Logging is not enabled for this container.
Please use https://aka.ms/linux-diagnostics to enable logging to see container logs here.
2018-04-10 04:16:51.819 INFO  - Starting container for site
2018-04-10 04:16:51.825 INFO  - docker run -d -p 62966:8080 --name [xxx] -e WEBSITES_ENABLE_APP_SERVICE_STORAGE=false -e DOCKER_CUSTOM_IMAGE_NAME=[xxx] -e WEBSITES_PORT=8080 -e WEBSITE_SITE_NAME=[xxx] -e WEBSITE_AUTH_ENABLED=False -e WEBSITE_ROLE_INSTANCE_ID=0 -e WEBSITE_INSTANCE_ID=[xxx] 
`